### PR TITLE
Splitting subnet outputs into individual outputs

### DIFF
--- a/Q2.template
+++ b/Q2.template
@@ -632,11 +632,23 @@
          "Description" : "The ID of the VPC this template just created.",
          "Value" : { "Ref" : "MozillaVpc" }
       },
-      "PublicSubnets": {
-         "Value" : {"Fn::Join": [ ",", [{"Ref": "PublicSubnetAZ1" }, { "Ref": "PublicSubnetAZ2" }, { "Ref": "PublicSubnetAZ3" }]]}
+      "PublicSubnetAZ1": {
+         "Value" : {"Ref": "PublicSubnetAZ1"}
       },
-      "PrivateSubnets": {
-         "Value" : {"Fn::Join": [ ",",[{"Ref": "PrivateSubnetAZ1" }, { "Ref": "PrivateSubnetAZ2" }, { "Ref": "PrivateSubnetAZ3"}]]}
+      "PublicSubnetAZ2": {
+         "Value" : {"Ref": "PublicSubnetAZ2"}
+      },
+      "PublicSubnetAZ3": {
+         "Value" : {"Ref": "PublicSubnetAZ3"}
+      },
+      "PrivateSubnetAZ1": {
+         "Value" : {"Ref": "PrivateSubnetAZ1"}
+      },
+      "PrivateSubnetAZ2": {
+         "Value" : {"Ref": "PrivateSubnetAZ2"}
+      },
+      "PrivateSubnetAZ3": {
+         "Value" : {"Ref": "PrivateSubnetAZ3"}
       },
       "SharedServicesSecurityGroupId" : {
           "Value" : { "Ref" : "SharedServicesSecurityGroup" }


### PR DESCRIPTION
Cloudformation treats the coma delimited lists as strings when they are pulled in from the output of another stack. This simply breaks them out into separate outputs, not quite as clean but I see no other option.